### PR TITLE
Added avoid for Cross shaped avoid. 

### DIFF
--- a/Avoid/CrossGeneric.cs
+++ b/Avoid/CrossGeneric.cs
@@ -1,4 +1,12 @@
-﻿using System;
+﻿/*
+SideStep is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+You should have received a copy of the license along with this
+work. If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>.
+Orginal work done by zzi
+                                                                                 */
+
+using System;
 using System.Collections.Generic;
 using ff14bot.Managers;
 using ff14bot.Objects;

--- a/Avoid/CrossGeneric.cs
+++ b/Avoid/CrossGeneric.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using ff14bot.Managers;
+using ff14bot.Objects;
+using ff14bot.Pathing.Avoidance;
+using Sidestep.Common;
+using Sidestep.Interfaces;
+using Sidestep.Logging;
+
+namespace Sidestep.Avoid
+{
+    [Avoider(AvoiderType.Omen, 188)]
+    public class CrossGeneric : Omen
+    {
+        public override IEnumerable<AvoidInfo> OmenHandle(BattleCharacter spellCaster)
+        {
+            var cached = spellCaster.CastingSpellId;
+            //var rotation = Rotation(spellCaster);
+            //var cl = spellCaster.SpellCastInfo.CastLocation;
+            var square = Square(spellCaster);
+            var result = new List<AvoidInfo>();
+            var range = Range(spellCaster, out var center);
+
+            Logger.Info($"Avoid Cross: [{center}][Range: {range}] EffectiveRange [{spellCaster.SpellCastInfo.SpellData.EffectRange}]");
+
+            result.Add(AvoidanceManager.AddAvoidPolygon(
+                () => spellCaster.IsValid && spellCaster.CastingSpellId == cached,
+                null,
+                40f,
+                bc => bc.Heading, //rotation
+                bc => 1.0f, //scale
+                bc => 15.0f, //height
+                bc => square, //points
+                bc => spellCaster.Location,
+                () => new[] {spellCaster} //objs
+            ));
+
+            result.Add(AvoidanceManager.AddAvoidPolygon(
+                () => spellCaster.IsValid && spellCaster.CastingSpellId == cached,
+                null,
+                40f,
+                bc => bc.Heading - (float) Math.PI, //rotation
+                bc => 1.0f, //scale
+                bc => 15.0f, //height
+                bc => square, //points
+                bc => spellCaster.Location,
+                () => new[] {spellCaster} //objs
+            ));
+            result.Add(AvoidanceManager.AddAvoidPolygon(
+                () => spellCaster.IsValid && spellCaster.CastingSpellId == cached,
+                null,
+                40f,
+                bc => bc.Heading - (float) Math.PI / 2, //rotation
+                bc => 1.0f, //scale
+                bc => 15.0f, //height
+                bc => square, //points
+                bc => spellCaster.Location,
+                () => new[] {spellCaster} //objs
+            ));
+            result.Add(AvoidanceManager.AddAvoidPolygon(
+                () => spellCaster.IsValid && spellCaster.CastingSpellId == cached,
+                null,
+                40f,
+                bc => bc.Heading + (float) Math.PI / 2, //rotation
+                bc => 1.0f, //scale
+                bc => 15.0f, //height
+                bc => square, //points
+                bc => spellCaster.Location,
+                () => new[] {spellCaster} //objs
+            ));
+
+            //Add circle right under mob
+            result.Add(AvoidanceManager.AddAvoidLocation(
+                () => spellCaster.IsValid && spellCaster.CastingSpellId == cached, //can run
+                3f,
+                () => spellCaster.Location
+            ));
+
+
+            return result.ToArray();
+        }
+    }
+}

--- a/SideStep.csproj
+++ b/SideStep.csproj
@@ -105,6 +105,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Avoid\CrossGeneric.cs" />
     <Compile Include="Avoid\LazerGeneric.cs" />
     <Compile Include="Avoid\Triangles.cs" />
     <Compile Include="Avoid\CircleGeneric.cs" />


### PR DESCRIPTION
Seems to work well on HoH mob, The aoe effect is plus shaped so a rectangle (taken from lazergeneric) is applied at the 4 rotational spots that correspond to cardinal directions and a small circle directly under the mob to keep from standing right under him. It's linked to omen 188 so should not interfere with other avoids and as of the current version (before this) sidestep complains a lot about not having an avoid setup for this cast.